### PR TITLE
Set root logging level to INFO

### DIFF
--- a/cmdb-model/src/main/resources/application.yaml
+++ b/cmdb-model/src/main/resources/application.yaml
@@ -31,5 +31,5 @@ log:
   operate-switch: true # 操作日志开关
 logging:
   level:
-    root: error
+    root: INFO
 ...


### PR DESCRIPTION
## Summary
- ensure INFO level logs print by configuring root log level to INFO

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for com.example:cmdb-backend:0.1.0: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_689aeef296a4832c8309ef0a26aa6e9e